### PR TITLE
Update Forge API Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>plugin-jboss-as7</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <forge.api.version>1.0.0-SNAPSHOT</forge.api.version>
+    <forge.api.version>1.0.5.Final</forge.api.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
The jboss-as-7 plugin was broken as it was still using the 1.0.0-SNAPSHOT version of the Forge API, causing build errors with more recent versions of Forge.  I have updated the API version to 1.0.5.Final.

For the long term, we need to find a way to support a range of Forge versions so that plugin POMs do not need to be updated for every release.  I'll bring this up at the next dev meeting.
